### PR TITLE
Basic implementation of optical drive launching

### DIFF
--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -5,6 +5,7 @@ package mister
 import (
 	"fmt"
 	"github.com/wizzomafizzo/tapto/pkg/api/models"
+	"github.com/wizzomafizzo/tapto/pkg/readers/optical_drive"
 	"os"
 	"os/exec"
 	"regexp"
@@ -72,6 +73,7 @@ func (p *Platform) SupportedReaders(cfg *config.UserConfig) []readers.Reader {
 		libnfc.NewReader(cfg),
 		file.NewReader(cfg),
 		simple_serial.NewReader(cfg),
+		optical_drive.NewReader(cfg),
 	}
 }
 

--- a/pkg/readers/optical_drive/optical_drive.go
+++ b/pkg/readers/optical_drive/optical_drive.go
@@ -1,0 +1,145 @@
+package optical_drive
+
+import (
+	"errors"
+	"github.com/rs/zerolog/log"
+	"github.com/wizzomafizzo/tapto/pkg/config"
+	"github.com/wizzomafizzo/tapto/pkg/readers"
+	"github.com/wizzomafizzo/tapto/pkg/tokens"
+	"github.com/wizzomafizzo/tapto/pkg/utils"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const TokenType = "disc"
+
+type FileReader struct {
+	cfg     *config.UserConfig
+	device  string
+	path    string
+	polling bool
+}
+
+func NewReader(cfg *config.UserConfig) *FileReader {
+	return &FileReader{
+		cfg: cfg,
+	}
+}
+
+func (r *FileReader) Ids() []string {
+	return []string{"optical_drive"}
+}
+
+func (r *FileReader) Open(device string, iq chan<- readers.Scan) error {
+	ps := strings.SplitN(device, ":", 2)
+	if len(ps) != 2 {
+		return errors.New("invalid device string: " + device)
+	}
+
+	if !utils.Contains(r.Ids(), ps[0]) {
+		return errors.New("invalid reader id: " + ps[0])
+	}
+
+	path := ps[1]
+
+	if !filepath.IsAbs(path) {
+		return errors.New("invalid device path, must be absolute")
+	}
+
+	parent := filepath.Dir(path)
+	if parent == "" {
+		return errors.New("invalid device path")
+	}
+
+	if _, err := os.Stat(parent); err != nil {
+		return err
+	}
+
+	r.device = device
+	r.path = path
+	r.polling = true
+
+	go func() {
+		var token *tokens.Token
+
+		for r.polling {
+			time.Sleep(1 * time.Second)
+
+			rawUuid, err := exec.Command("blkid", "-o", "value", "-s", "UUID", r.path).Output()
+			if err != nil {
+				if token != nil {
+					log.Debug().Err(err).Msg("error identifying optical media, removing token")
+					token = nil
+					iq <- readers.Scan{
+						Source: r.device,
+						Token:  nil,
+					}
+				} else {
+					continue
+				}
+			}
+
+			uuid := strings.TrimSpace(string(rawUuid))
+
+			if uuid == "" && token != nil {
+				log.Debug().Msg("id is empty, removing token")
+				token = nil
+				iq <- readers.Scan{
+					Source: r.device,
+					Token:  nil,
+				}
+				continue
+			}
+
+			if token != nil && token.UID == uuid {
+				continue
+			}
+
+			if uuid == "" {
+				continue
+			}
+
+			token = &tokens.Token{
+				Type:     TokenType,
+				ScanTime: time.Now(),
+				UID:      uuid,
+			}
+
+			log.Debug().Msgf("new token: %s", token.UID)
+			iq <- readers.Scan{
+				Source: r.device,
+				Token:  token,
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (r *FileReader) Close() error {
+	r.polling = false
+	return nil
+}
+
+func (r *FileReader) Detect(connected []string) string {
+	return ""
+}
+
+func (r *FileReader) Device() string {
+	return r.device
+}
+
+func (r *FileReader) Connected() bool {
+	return r.polling
+}
+
+func (r *FileReader) Info() string {
+	return r.path
+}
+
+func (r *FileReader) Write(text string) (*tokens.Token, error) {
+	return nil, nil
+}


### PR DESCRIPTION
MiSTer only right now, enable by adding `reader=optical_drive:/dev/sr0` to ini file with an external CD drive plugged in

Uses the discs UUID as the token UID which is populated during a burn. Does not currently read any files off the disc itself, but does require it to be burned to have a UUID. A mapping needs to be assigned for the UID

I suggest adding a file called "tapto.txt" to the root of the disc with the desired future launch text, so you're not just wasting discs (or use any already burned discs you have lying around). It should be supported later