### PR TITLE
tty2old fixes

### DIFF
--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -51,9 +51,19 @@ tasks:
       IMG_MODCACHE: /home/build/go/pkg/mod
     cmds:
       - docker run --rm --platform linux/arm/v7 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.MODCACHE}}:{{.IMG_MODCACHE}} -v ${PWD}:/build --user 1000:1000 {{.IMAGE_NAME}} build.sh
-      - cp ./scripts/taptui/taptui.sh {{.BUILD_DIR}}
       - rm -f {{.BUILD_DIR}}/tapto-mister_arm.zip
-      - zip -j {{.BUILD_DIR}}/tapto-mister_arm.zip {{.BUILD_DIR}}/tapto.sh {{.BUILD_DIR}}/taptui.sh
+      - zip -j {{.BUILD_DIR}}/tapto-mister_arm.zip {{.BUILD_DIR}}/tapto.sh
+
+  build-mister-shell:
+    vars:
+      BUILD_DIR: "./_build/mister_arm"
+      BUILDCACHE: "{{.BUILD_DIR}}/.go-buildcache"
+      MODCACHE: "{{.BUILD_DIR}}/.go-modcache"
+      IMAGE_NAME: tapto/mister-build
+      IMG_BUILDCACHE: /home/build/.cache/go-build
+      IMG_MODCACHE: /home/build/go/pkg/mod
+    cmds:
+      - docker run --rm --platform linux/arm/v7 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.MODCACHE}}:{{.IMG_MODCACHE}} -v ${PWD}:/build --user 1000:1000 -ti {{.IMAGE_NAME}} /bin/bash
 
   build-mistex:
     vars:

--- a/pkg/readers/libnfc/libnfc.go
+++ b/pkg/readers/libnfc/libnfc.go
@@ -62,6 +62,7 @@ func (r *Reader) Open(device string, iq chan<- readers.Scan) error {
 		connStr = ""
 	}
 
+	log.Debug().Msgf("opening device: %s", connStr)
 	pnd, err := openDeviceWithRetries(connStr)
 	if err != nil {
 		if device == autoConnStr {
@@ -132,6 +133,7 @@ func (r *Reader) Close() error {
 	if r.pnd == nil {
 		return nil
 	} else {
+		log.Debug().Msgf("closing device: %s", r.conn)
 		return r.pnd.Close()
 	}
 }

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -77,6 +77,7 @@ func connectReaders(
 			for _, r := range pl.SupportedReaders(cfg) {
 				ids := r.Ids()
 				if utils.Contains(ids, rt) {
+					log.Debug().Msgf("connecting to reader: %s", device)
 					err := r.Open(device, iq)
 					if err != nil {
 						log.Error().Msgf("error opening reader: %s", err)

--- a/pkg/utils/serial.go
+++ b/pkg/utils/serial.go
@@ -82,7 +82,7 @@ func ignoreSerialDevice(path string) bool {
 }
 
 func getLinuxList() ([]string, error) {
-	path := "/dev/serial/by-id"
+	path := "/dev"
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return nil, nil
@@ -95,7 +95,7 @@ func getLinuxList() ([]string, error) {
 	defer func(f *os.File) {
 		err := f.Close()
 		if err != nil {
-			log.Warn().Err(err).Msg("failed to close serial device")
+			log.Warn().Err(err).Msg("failed to close serial device folder")
 		}
 	}(f)
 
@@ -108,6 +108,10 @@ func getLinuxList() ([]string, error) {
 
 	for _, v := range files {
 		if v.IsDir() {
+			continue
+		}
+
+		if !strings.HasPrefix(v.Name(), "ttyUSB") && !strings.HasPrefix(v.Name(), "ttyACM") {
 			continue
 		}
 

--- a/scripts/mister/build/Dockerfile
+++ b/scripts/mister/build/Dockerfile
@@ -39,8 +39,10 @@ RUN cd /internal && \
     git clone --depth 1 https://github.com/nfc-tools/libnfc.git
 # apply patches
 COPY patches/pcsc-initiator_poll_target.patch /internal/libnfc/pcsc-initiator_poll_target.patch
+COPY patches/uart_flock.patch /internal/libnfc/uart_flock.patch
 RUN cd /internal/libnfc && \
-    patch -p1 < pcsc-initiator_poll_target.patch
+    patch -p1 < pcsc-initiator_poll_target.patch && \
+    patch -p1 < uart_flock.patch
 # build and install libnfc
 RUN cd /internal/libnfc && \
     autoreconf -vis && \

--- a/scripts/mister/build/patches/uart_flock.patch
+++ b/scripts/mister/build/patches/uart_flock.patch
@@ -1,0 +1,54 @@
+From 7ff5d11127684865b3509510373605b44c0b1c73 Mon Sep 17 00:00:00 2001
+From: Giovanni Giacobbi <giovanni@giacobbi.net>
+Date: Tue, 13 Apr 2021 12:13:20 +0000
+Subject: [PATCH] buses/uart: Use 'lockf()' for serial locking
+
+Using this standard Linux mechanism to lock serial ports has the advantage that if the process is killed the lock is automatically released.
+
+Before a lock was simulated using the custom termios 'c_iflag' value 0x80000000, which has the disadvantage, other than being non-standard, that if the process is killed before closing the serial port, it would appear as locked and require manual cleanup of the flag.
+
+Signed-off-by: Giovanni Giacobbi <giovanni@giacobbi.net>
+---
+ libnfc/buses/uart.c | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/libnfc/buses/uart.c b/libnfc/buses/uart.c
+index ffe64aa5..c2bcf8c3 100644
+--- a/libnfc/buses/uart.c
++++ b/libnfc/buses/uart.c
+@@ -92,9 +92,6 @@ const char *serial_ports_device_radix[] = { "ttyUSB", "ttyS", "ttyACM", "ttyAMA"
+ #  define FIONREAD TIOCINQ
+ #endif
+
+-// Work-around to claim uart interface using the c_iflag (software input processing) from the termios struct
+-#  define CCLAIMED 0x80000000
+-
+ struct serial_port_unix {
+   int 			fd; 			// Serial port file descriptor
+   struct termios 	termios_backup; 	// Terminal info before using the port
+@@ -124,7 +121,7 @@ uart_open(const char *pcPortName)
+     return INVALID_SERIAL_PORT;
+   }
+   // Make sure the port is not claimed already
+-  if (sp->termios_backup.c_iflag & CCLAIMED) {
++  if (lockf(sp->fd, F_TLOCK, 0)) {
+     uart_close_ext(sp, false);
+     return CLAIMED_SERIAL_PORT;
+   }
+@@ -132,7 +129,7 @@ uart_open(const char *pcPortName)
+   sp->termios_new = sp->termios_backup;
+
+   sp->termios_new.c_cflag = CS8 | CLOCAL | CREAD;
+-  sp->termios_new.c_iflag = CCLAIMED | IGNPAR;
++  sp->termios_new.c_iflag = IGNPAR;
+   sp->termios_new.c_oflag = 0;
+   sp->termios_new.c_lflag = 0;
+
+@@ -282,6 +279,7 @@ uart_close_ext(const serial_port sp, const bool restore_termios)
+   if (UART_DATA(sp)->fd >= 0) {
+     if (restore_termios)
+       tcsetattr(UART_DATA(sp)->fd, TCSANOW, &UART_DATA(sp)->termios_backup);
++    lockf(UART_DATA(sp)->fd, F_ULOCK, 0);
+     close(UART_DATA(sp)->fd);
+   }
+   free(sp);


### PR DESCRIPTION
Attempting to get TapTo and tty2oled to work better together

- Add a supposedly better kernel lock method to libnfc
- Use direct ttyUSB and ttyACM dev nodes instead of /dev/serial (also fixes issue with multiple cheap readers plugged in at once)