### PR TITLE
Add support for various launchers and core files

### DIFF
--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -130,14 +130,12 @@ tasks:
   deploy-mister:
     cmds:
       - task: build-mister
-      - scp _build/mister_arm/taptui.sh root@${MISTER_IP}:/media/fat/Scripts/taptui.sh
       - scp _build/mister_arm/tapto.sh root@${MISTER_IP}:/media/fat/Scripts/tapto.sh
       - ssh root@${MISTER_IP} /media/fat/Scripts/tapto.sh -service restart
 
   deploy-mistex:
     cmds:
       - task: build-mistex
-      - scp _build/mistex_arm64/taptui.sh root@${MISTEX_IP}:/media/fat/Scripts/taptui.sh
       - scp _build/mistex_arm64/tapto.sh root@${MISTEX_IP}:/media/fat/Scripts/tapto.sh
       - ssh root@${MISTEX_IP} /media/fat/Scripts/tapto.sh -service restart
 

--- a/pkg/api/methods/games.go
+++ b/pkg/api/methods/games.go
@@ -62,7 +62,7 @@ func (s *Index) GenerateIndex(
 	go func() {
 		defer s.mu.Unlock()
 
-		_, err := gamesdb.NewNamesIndex(pl, cfg, systems, func(status gamesdb.IndexStatus) {
+		total, err := gamesdb.NewNamesIndex(pl, cfg, systems, func(status gamesdb.IndexStatus) {
 			s.TotalSteps = status.Total
 			s.CurrentStep = status.Step
 			s.TotalFiles = status.Files
@@ -83,7 +83,7 @@ func (s *Index) GenerateIndex(
 					}
 				}
 			}
-			log.Info().Msgf("indexing status: %s", s.CurrentDesc)
+			log.Debug().Msgf("indexing status: %v", s)
 			ns <- models.Notification{
 				Method: models.MediaIndexing,
 				Params: models.IndexStatusResponse{
@@ -103,6 +103,7 @@ func (s *Index) GenerateIndex(
 		s.TotalSteps = 0
 		s.CurrentStep = 0
 		s.CurrentDesc = ""
+		s.TotalFiles = 0
 
 		log.Info().Msg("finished generating media index")
 		ns <- models.Notification{
@@ -112,7 +113,7 @@ func (s *Index) GenerateIndex(
 				TotalSteps:  0,
 				CurrentStep: 0,
 				CurrentDesc: "",
-				TotalFiles:  0,
+				TotalFiles:  total,
 			},
 		}
 	}()

--- a/pkg/assets/systems/NeoGeo.json
+++ b/pkg/assets/systems/NeoGeo.json
@@ -1,7 +1,7 @@
 {
   "id": "NeoGeo",
-  "name": "Neo Geo CD",
+  "name": "Neo Geo",
   "category": "Console",
-  "releaseDate": "1994-09-09",
+  "releaseDate": "1990-01-01",
   "manufacturer": "SNK"
 }

--- a/pkg/assets/systems/NeoGeoCD.json
+++ b/pkg/assets/systems/NeoGeoCD.json
@@ -1,0 +1,7 @@
+{
+  "id": "NeoGeoCD",
+  "name": "Neo Geo CD",
+  "category": "Console",
+  "releaseDate": "1994-09-09",
+  "manufacturer": "SNK"
+}

--- a/pkg/database/gamesdb/gamesdb.go
+++ b/pkg/database/gamesdb/gamesdb.go
@@ -177,7 +177,7 @@ func NewNamesIndex(
 	update func(IndexStatus),
 ) (int, error) {
 	status := IndexStatus{
-		Total: len(systems) + 1,
+		Total: len(systems) + 2, // estimate steps
 		Step:  1,
 	}
 
@@ -227,7 +227,11 @@ func NewNamesIndex(
 		scanned[s.Id] = false
 	}
 
-	for _, k := range utils.AlphaMapKeys(systemPaths) {
+	sysPathIds := utils.AlphaMapKeys(systemPaths)
+	// update steps with true count
+	status.Total = len(sysPathIds) + 2
+
+	for _, k := range sysPathIds {
 		systemId := k
 		files := make([]platforms.ScanResult, 0)
 

--- a/pkg/database/gamesdb/systems.go
+++ b/pkg/database/gamesdb/systems.go
@@ -260,7 +260,7 @@ var Systems = map[string]System{
 		Id: SystemNeoGeo,
 	},
 	SystemNeoGeoCD: {
-		Id: SystemNeoGeo,
+		Id: SystemNeoGeoCD,
 	},
 	SystemNES: {
 		Id: SystemNES,

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -385,6 +385,11 @@ var Launchers = []platforms.Launcher{
 		Launch:   launchSinden(gamesdb.SystemPSX, "PSX"),
 	},
 	{
+		Id:       "2XPSX",
+		SystemId: gamesdb.SystemPSX,
+		Launch:   launchAltCore(gamesdb.SystemPSX, "_Console/PSX2XCPU"),
+	},
+	{
 		Id:         gamesdb.SystemSega32X,
 		SystemId:   gamesdb.SystemSega32X,
 		Folders:    []string{"S32X"},

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -565,13 +565,6 @@ var Launchers = []platforms.Launcher{
 		Launch:     launch,
 	},
 	{
-		Id:         gamesdb.SystemAmiga,
-		SystemId:   gamesdb.SystemAmiga,
-		Folders:    []string{"Amiga"},
-		Extensions: []string{".adf"},
-		Launch:     launch,
-	},
-	{
 		Id:         gamesdb.SystemAmstrad,
 		SystemId:   gamesdb.SystemAmstrad,
 		Folders:    []string{"Amstrad"},

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -33,6 +33,22 @@ func launchSinden(
 	}
 }
 
+func launchAltCore(
+	systemId string,
+	rbfPath string,
+) func(*config.UserConfig, string) error {
+	return func(cfg *config.UserConfig, path string) error {
+		s, err := games.GetSystem(systemId)
+		if err != nil {
+			return err
+		}
+		sn := *s
+		sn.Rbf = rbfPath
+		log.Debug().Str("rbf", sn.Rbf).Msgf("launching alt core: %v", sn)
+		return mister.LaunchGame(UserConfigToMrext(cfg), sn, path)
+	}
+}
+
 var Launchers = []platforms.Launcher{
 	// Consoles
 	{
@@ -64,6 +80,11 @@ var Launchers = []platforms.Launcher{
 		Launch:     launch,
 	},
 	{
+		Id:       "LLAPIAtari2600",
+		SystemId: gamesdb.SystemAtari2600,
+		Launch:   launchAltCore(gamesdb.SystemAtari2600, "_LLAPI/Atari7800_LLAPI"),
+	},
+	{
 		Id:         gamesdb.SystemAtari5200,
 		SystemId:   gamesdb.SystemAtari5200,
 		Folders:    []string{"ATARI5200"},
@@ -76,6 +97,11 @@ var Launchers = []platforms.Launcher{
 		Folders:    []string{"ATARI7800"},
 		Extensions: []string{".a78"},
 		Launch:     launch,
+	},
+	{
+		Id:       "LLAPIAtari7800",
+		SystemId: gamesdb.SystemAtari7800,
+		Launch:   launchAltCore(gamesdb.SystemAtari7800, "_LLAPI/Atari7800_LLAPI"),
 	},
 	{
 		Id:         gamesdb.SystemAtariLynx,
@@ -134,6 +160,11 @@ var Launchers = []platforms.Launcher{
 		Launch:     launch,
 	},
 	{
+		Id:       "LLAPIGameboy",
+		SystemId: gamesdb.SystemGameboy,
+		Launch:   launchAltCore(gamesdb.SystemGameboy, "_LLAPI/Gameboy_LLAPI"),
+	},
+	{
 		Id:         gamesdb.SystemGameboyColor,
 		SystemId:   gamesdb.SystemGameboyColor,
 		Folders:    []string{"GAMEBOY", "GBC"},
@@ -169,6 +200,11 @@ var Launchers = []platforms.Launcher{
 		Launch:     launch,
 	},
 	{
+		Id:       "LLAPIGBA",
+		SystemId: gamesdb.SystemGBA,
+		Launch:   launchAltCore(gamesdb.SystemGBA, "_LLAPI/GBA_LLAPI"),
+	},
+	{
 		Id:         gamesdb.SystemGBA2P,
 		SystemId:   gamesdb.SystemGBA2P,
 		Folders:    []string{"GBA2P"},
@@ -193,6 +229,11 @@ var Launchers = []platforms.Launcher{
 		Launch:   launchSinden(gamesdb.SystemGenesis, "MegaDrive"),
 	},
 	{
+		Id:       "LLAPIMegaDrive",
+		SystemId: gamesdb.SystemGenesis,
+		Launch:   launchAltCore(gamesdb.SystemGenesis, "_LLAPI/MegaDrive_LLAPI"),
+	},
+	{
 		Id:         gamesdb.SystemIntellivision,
 		SystemId:   gamesdb.SystemIntellivision,
 		Folders:    []string{"Intellivision"},
@@ -212,6 +253,11 @@ var Launchers = []platforms.Launcher{
 		Launch:   launchSinden(gamesdb.SystemMasterSystem, "SMS"),
 	},
 	{
+		Id:       "LLAPISMS",
+		SystemId: gamesdb.SystemMasterSystem,
+		Launch:   launchAltCore(gamesdb.SystemMasterSystem, "_LLAPI/SMS_LLAPI"),
+	},
+	{
 		Id:         gamesdb.SystemMegaCD,
 		SystemId:   gamesdb.SystemMegaCD,
 		Folders:    []string{"MegaCD"},
@@ -222,6 +268,11 @@ var Launchers = []platforms.Launcher{
 		Id:       "SindenMegaCD",
 		SystemId: gamesdb.SystemMegaCD,
 		Launch:   launchSinden(gamesdb.SystemMegaCD, "MegaCD"),
+	},
+	{
+		Id:       "LLAPIMegaCD",
+		SystemId: gamesdb.SystemMegaCD,
+		Launch:   launchAltCore(gamesdb.SystemMegaCD, "_LLAPI/MegaCD_LLAPI"),
 	},
 	{
 		Id:         gamesdb.SystemMegaDuck,
@@ -238,8 +289,13 @@ var Launchers = []platforms.Launcher{
 		Launch:     launch,
 	},
 	{
-		Id:         gamesdb.SystemNeoGeo,
-		SystemId:   gamesdb.SystemNeoGeo,
+		Id:       "LLAPINeoGeo",
+		SystemId: gamesdb.SystemNeoGeo,
+		Launch:   launchAltCore(gamesdb.SystemNeoGeo, "_LLAPI/NeoGeo_LLAPI"),
+	},
+	{
+		Id:         gamesdb.SystemNeoGeoCD,
+		SystemId:   gamesdb.SystemNeoGeoCD,
 		Folders:    []string{"NeoGeo-CD", "NEOGEO"},
 		Extensions: []string{".cue", ".chd"},
 		Launch:     launch,
@@ -264,11 +320,26 @@ var Launchers = []platforms.Launcher{
 		Launch:     launch,
 	},
 	{
+		Id:       "LLAPINES",
+		SystemId: gamesdb.SystemNES,
+		Launch:   launchAltCore(gamesdb.SystemNES, "_LLAPI/NES_LLAPI"),
+	},
+	{
 		Id:         gamesdb.SystemNintendo64,
 		SystemId:   gamesdb.SystemNintendo64,
 		Folders:    []string{"N64"},
 		Extensions: []string{".n64", ".z64"},
 		Launch:     launch,
+	},
+	{
+		Id:       "LLAPINintendo64",
+		SystemId: gamesdb.SystemNintendo64,
+		Launch:   launchAltCore(gamesdb.SystemNintendo64, "_LLAPI/N64_LLAPI"),
+	},
+	{
+		Id:       "LLAPI80MHzNintendo64",
+		SystemId: gamesdb.SystemNintendo64,
+		Launch:   launchAltCore(gamesdb.SystemNintendo64, "_LLAPI/N64_80MHz_LLAPI"),
 	},
 	{
 		Id:         gamesdb.SystemOdyssey2,
@@ -299,6 +370,11 @@ var Launchers = []platforms.Launcher{
 		Launch:     launch,
 	},
 	{
+		Id:       "LLAPIPSX",
+		SystemId: gamesdb.SystemPSX,
+		Launch:   launchAltCore(gamesdb.SystemPSX, "_LLAPI/PSX_LLAPI"),
+	},
+	{
 		Id:       "SindenPSX",
 		SystemId: gamesdb.SystemPSX,
 		Launch:   launchSinden(gamesdb.SystemPSX, "PSX"),
@@ -309,6 +385,11 @@ var Launchers = []platforms.Launcher{
 		Folders:    []string{"S32X"},
 		Extensions: []string{".32x"},
 		Launch:     launch,
+	},
+	{
+		Id:       "LLAPIS32X",
+		SystemId: gamesdb.SystemSega32X,
+		Launch:   launchAltCore(gamesdb.SystemPSX, "_LLAPI/S32X_LLAPI"),
 	},
 	{
 		Id:         gamesdb.SystemSG1000,
@@ -325,6 +406,11 @@ var Launchers = []platforms.Launcher{
 		Launch:     launch,
 	},
 	{
+		Id:       "LLAPISuperGameboy",
+		SystemId: gamesdb.SystemSuperGameboy,
+		Launch:   launchAltCore(gamesdb.SystemSuperGameboy, "_LLAPI/SGB_LLAPI"),
+	},
+	{
 		Id:         gamesdb.SystemSuperVision,
 		SystemId:   gamesdb.SystemSuperVision,
 		Folders:    []string{"SuperVision"},
@@ -339,11 +425,21 @@ var Launchers = []platforms.Launcher{
 		Launch:     launch,
 	},
 	{
+		Id:       "LLAPISaturn",
+		SystemId: gamesdb.SystemSaturn,
+		Launch:   launchAltCore(gamesdb.SystemSaturn, "_LLAPI/Saturn_LLAPI"),
+	},
+	{
 		Id:         gamesdb.SystemSNES,
 		SystemId:   gamesdb.SystemSNES,
 		Folders:    []string{"SNES"},
 		Extensions: []string{".sfc", ".smc", ".bin", ".bs"},
 		Launch:     launch,
+	},
+	{
+		Id:       "LLAPISNES",
+		SystemId: gamesdb.SystemSNES,
+		Launch:   launchAltCore(gamesdb.SystemSNES, "_LLAPI/SNES_LLAPI"),
 	},
 	{
 		Id:       "SindenSNES",
@@ -370,6 +466,11 @@ var Launchers = []platforms.Launcher{
 		Folders:    []string{"TGFX16"},
 		Extensions: []string{".pce", ".bin"},
 		Launch:     launch,
+	},
+	{
+		Id:       "LLAPITurboGrafx16",
+		SystemId: gamesdb.SystemTurboGrafx16,
+		Launch:   launchAltCore(gamesdb.SystemTurboGrafx16, "_LLAPI/TurboGrafx16_LLAPI"),
 	},
 	{
 		Id:         gamesdb.SystemTurboGrafx16CD,

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -342,6 +342,11 @@ var Launchers = []platforms.Launcher{
 		Launch:   launchAltCore(gamesdb.SystemNintendo64, "_LLAPI/N64_80MHz_LLAPI"),
 	},
 	{
+		Id:       "80MHzNintendo64",
+		SystemId: gamesdb.SystemNintendo64,
+		Launch:   launchAltCore(gamesdb.SystemNintendo64, "_Console/N64_80MHz"),
+	},
+	{
 		Id:         gamesdb.SystemOdyssey2,
 		SystemId:   gamesdb.SystemOdyssey2,
 		Folders:    []string{"ODYSSEY2"},

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -282,13 +282,6 @@ var Launchers = []platforms.Launcher{
 		Launch:     launch,
 	},
 	{
-		Id:         gamesdb.SystemNeoGeo,
-		SystemId:   gamesdb.SystemNeoGeo,
-		Folders:    []string{"NEOGEO"},
-		Extensions: []string{".neo"}, // TODO: .zip and folder support
-		Launch:     launch,
-	},
-	{
 		Id:       "LLAPINeoGeo",
 		SystemId: gamesdb.SystemNeoGeo,
 		Launch:   launchAltCore(gamesdb.SystemNeoGeo, "_LLAPI/NeoGeo_LLAPI"),

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -347,6 +347,16 @@ var Launchers = []platforms.Launcher{
 		Launch:   launchAltCore(gamesdb.SystemNintendo64, "_Console/N64_80MHz"),
 	},
 	{
+		Id:       "PWMNintendo64",
+		SystemId: gamesdb.SystemNintendo64,
+		Launch:   launchAltCore(gamesdb.SystemNintendo64, "_ConsolePWM/N64_PWM"),
+	},
+	{
+		Id:       "PWM80MHzNintendo64",
+		SystemId: gamesdb.SystemNintendo64,
+		Launch:   launchAltCore(gamesdb.SystemNintendo64, "_ConsolePWM/_Turbo/N64_80MHz_PWM"),
+	},
+	{
 		Id:         gamesdb.SystemOdyssey2,
 		SystemId:   gamesdb.SystemOdyssey2,
 		Folders:    []string{"ODYSSEY2"},
@@ -388,6 +398,16 @@ var Launchers = []platforms.Launcher{
 		Id:       "2XPSX",
 		SystemId: gamesdb.SystemPSX,
 		Launch:   launchAltCore(gamesdb.SystemPSX, "_Console/PSX2XCPU"),
+	},
+	{
+		Id:       "PWMPSX",
+		SystemId: gamesdb.SystemPSX,
+		Launch:   launchAltCore(gamesdb.SystemPSX, "_ConsolePWM/PSX_PWM"),
+	},
+	{
+		Id:       "PWM2XPSX",
+		SystemId: gamesdb.SystemPSX,
+		Launch:   launchAltCore(gamesdb.SystemPSX, "_ConsolePWM/_Turbo/PSX2XCPU_PWM"),
 	},
 	{
 		Id:         gamesdb.SystemSega32X,
@@ -438,6 +458,11 @@ var Launchers = []platforms.Launcher{
 		Id:       "LLAPISaturn",
 		SystemId: gamesdb.SystemSaturn,
 		Launch:   launchAltCore(gamesdb.SystemSaturn, "_LLAPI/Saturn_LLAPI"),
+	},
+	{
+		Id:       "PWMSaturn",
+		SystemId: gamesdb.SystemPSX,
+		Launch:   launchAltCore(gamesdb.SystemPSX, "_ConsolePWM/Saturn_PWM"),
 	},
 	{
 		Id:         gamesdb.SystemSNES,

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -4,6 +4,7 @@ package mister
 
 import (
 	"bufio"
+	"encoding/xml"
 	"fmt"
 	"github.com/wizzomafizzo/tapto/pkg/api/models"
 	"github.com/wizzomafizzo/tapto/pkg/database/gamesdb"
@@ -13,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/bendahl/uinput"
@@ -389,6 +391,31 @@ func (p *Platform) LookupMapping(t tokens.Token) (string, bool) {
 	return "", false
 }
 
+type Romset struct {
+	Name    string `xml:"name,attr"`
+	AltName string `xml:"altname,attr"`
+}
+
+type Romsets struct {
+	XMLName xml.Name `xml:"romsets"`
+	Romsets []Romset `xml:"romset"`
+}
+
+func readRomsets(filepath string) ([]Romset, error) {
+	f, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer f.Close()
+
+	var romsets Romsets
+	if err := xml.NewDecoder(f).Decode(&romsets); err != nil {
+		return nil, fmt.Errorf("failed to decode XML: %w", err)
+	}
+
+	return romsets.Romsets, nil
+}
+
 func (p *Platform) Launchers() []platforms.Launcher {
 	amiga := platforms.Launcher{
 		Id:         gamesdb.SystemAmiga,
@@ -446,7 +473,75 @@ func (p *Platform) Launchers() []platforms.Launcher {
 		},
 	}
 
+	neogeo := platforms.Launcher{
+		Id:         gamesdb.SystemNeoGeo,
+		SystemId:   gamesdb.SystemNeoGeo,
+		Folders:    []string{"NEOGEO"},
+		Extensions: []string{".neo"}, // TODO: .zip and folder support
+		Launch:     launch,
+		Scanner: func(
+			cfg *config.UserConfig,
+			results []platforms.ScanResult,
+		) ([]platforms.ScanResult, error) {
+			log.Info().Msg("starting neogeo scan")
+			romsetsFilename := "romsets.xml"
+			names := make(map[string]string)
+
+			s, err := gamesdb.GetSystem(gamesdb.SystemNeoGeo)
+			if err != nil {
+				return results, err
+			}
+
+			sfs := gamesdb.GetSystemPaths(p, p.RootFolders(cfg), []gamesdb.System{*s})
+			for _, sf := range sfs {
+				rsf, err := gamesdb.FindPath(filepath.Join(sf.Path, romsetsFilename))
+				if err == nil {
+					romsets, err := readRomsets(rsf)
+					if err != nil {
+						log.Warn().Err(err).Msg("unable to read romsets")
+						continue
+					}
+
+					for _, romset := range romsets {
+						names[romset.Name] = romset.AltName
+					}
+				}
+
+				// read directory
+				dir, err := os.Open(sf.Path)
+				if err != nil {
+					log.Warn().Err(err).Msg("unable to open neogeo directory")
+					continue
+				}
+
+				files, err := dir.Readdirnames(-1)
+				if err != nil {
+					log.Warn().Err(err).Msg("unable to read neogeo directory")
+					_ = dir.Close()
+					continue
+				}
+
+				for _, f := range files {
+					id := f
+					if filepath.Ext(strings.ToLower(f)) == ".zip" {
+						id = strings.TrimSuffix(f, filepath.Ext(f))
+					}
+
+					if altName, ok := names[id]; ok {
+						results = append(results, platforms.ScanResult{
+							Path: filepath.Join(sf.Path, f),
+							Name: altName,
+						})
+					}
+				}
+			}
+
+			return results, nil
+		},
+	}
+
 	ls := Launchers
 	ls = append(ls, amiga)
+	ls = append(ls, neogeo)
 	return ls
 }

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -54,9 +54,7 @@ func (p *Platform) ReadersUpdateHook(readers map[string]*readers.Reader) error {
 }
 
 func (p *Platform) RootFolders(cfg *config.UserConfig) []string {
-	return []string{
-		"C:\\scratch",
-	}
+	return []string{}
 }
 
 func (p *Platform) ZipsAsFolders() bool {

--- a/pkg/readers/libnfc/libnfc.go
+++ b/pkg/readers/libnfc/libnfc.go
@@ -60,9 +60,10 @@ func (r *Reader) Open(device string, iq chan<- readers.Scan) error {
 	connStr := device
 	if device == autoConnStr {
 		connStr = ""
+	} else {
+		log.Debug().Msgf("opening device: %s", connStr)
 	}
 
-	log.Debug().Msgf("opening device: %s", connStr)
 	pnd, err := openDeviceWithRetries(connStr)
 	if err != nil {
 		if device == autoConnStr {

--- a/pkg/service/state/state.go
+++ b/pkg/service/state/state.go
@@ -49,7 +49,13 @@ func (s *State) SetActiveCard(card tokens.Token) {
 
 	s.Notifications <- models.Notification{
 		Method: models.TokensActive,
-		Params: card,
+		Params: models.TokenResponse{
+			Type:     card.Type,
+			UID:      card.UID,
+			Text:     card.Text,
+			Data:     card.Data,
+			ScanTime: card.ScanTime,
+		},
 	}
 	s.mu.Unlock()
 }


### PR DESCRIPTION
- Fix NeoGeo and NeoGeoCD definitions so both will show correctly in search
- Fix tokens.active notification to match spec
- Fix step estimation in index notification to dynamically update total
- Add support for alternate cores: all LLAPI consoles, turbo N64, 2X PSX and PWM variants
- Add indexing support for AmigaVision games and demos so they show in search
- Add indexing support for NeoGeo .zip and folder games so they show in search